### PR TITLE
Application creation refactoring

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,9 +1,10 @@
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/c42fc2dbed964964985ca34c03c99d7c)](https://www.codacy.com/app/bhalexx/bilemo?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=bhalexx/bilemo&amp;utm_campaign=Badge_Grade)
-
 BileMo API
 ===========
 
 Version 0.0.0
+
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/c42fc2dbed964964985ca34c03c99d7c)](https://www.codacy.com/app/bhalexx/bilemo?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=bhalexx/bilemo&amp;utm_campaign=Badge_Grade)
+
 
 ---
 

--- a/api/app/Resources/views/Email/client_creation.html.twig
+++ b/api/app/Resources/views/Email/client_creation.html.twig
@@ -1,0 +1,13 @@
+Welcome to Bilemo Galaxy, {{ username }}!<br/>
+Here are your credentials to access our API:<br/>
+
+<pre>
+	{
+		client_id: {{ client_id }}
+		client_secret: {{ client_secret }}
+		username: {{ username }}
+		password: {{ password }}
+		grant_type: password
+	}
+</pre>
+

--- a/api/app/config/nelmio_config.yml
+++ b/api/app/config/nelmio_config.yml
@@ -6,7 +6,7 @@ nelmio_api_doc:
     info:
       description: |
         Discover all Bilemo API methods you can use as a Bilemo partner.
-        Use your credentials (`clientId`, `clientSecret`, `username` & `password`) to be authorized to try all those methods out.
+        Use your credentials (`clientId`, `clientSecret`, `username` & `password`) to get authorization to try all those methods out.
         Not a Bilemo Partner? What are you waiting for? Be part of us! [Contact us](http://google.com) to talk about your project.
       version: 1.0.0
       title: Bilemo API

--- a/api/app/config/services.yml
+++ b/api/app/config/services.yml
@@ -29,8 +29,25 @@ services:
         public: true
         tags: ['controller.service_arguments']
 
-    
-    # add more services, or override services that need manual wiring
-    # AppBundle\Service\ExampleService:
-    #     arguments:
-    #         $someArgument: 'some_value'
+    client.mailer:
+        class: AppBundle\Services\ClientMailer
+        arguments:
+            - "@mailer"
+            - "@templating"
+
+    application.password_generator:
+        class: AppBundle\Services\ApplicationPasswordGenerator
+
+    application.doctrine_listener.on_creation:
+        class: AppBundle\DoctrineListener\ApplicationCreationListener
+        arguments:
+            - "@application.password_generator"
+        tags:
+            - { name: doctrine.event_listener, event: prePersist }
+
+    client.doctrine_listener.on_creation:
+        class: AppBundle\DoctrineListener\ClientCreationListener
+        arguments:
+            - "@client.mailer"
+        tags:
+            - { name: doctrine.event_listener, event: postPersist }

--- a/api/src/AppBundle/Controller/ApplicationController.php
+++ b/api/src/AppBundle/Controller/ApplicationController.php
@@ -8,7 +8,6 @@ use FOS\RestBundle\Controller\Annotations as Rest;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use AppBundle\Entity\Application;
 
 class ApplicationController extends FOSRestController
@@ -58,7 +57,7 @@ class ApplicationController extends FOSRestController
      *
      * @ParamConverter("application", converter="fos_rest.request_body")
      */
-    public function createAction(Application $application, UserPasswordEncoderInterface $encoder)
+    public function createAction(Application $application)
     {
         $em = $this->getDoctrine()->getManager();
 

--- a/api/src/AppBundle/Controller/ApplicationController.php
+++ b/api/src/AppBundle/Controller/ApplicationController.php
@@ -62,25 +62,18 @@ class ApplicationController extends FOSRestController
     {
         $em = $this->getDoctrine()->getManager();
 
-        //Todo: remove this from here - create service to do this + send email with client's credentials
-        $chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        $plainPassword = substr(str_shuffle($chars), 0, 25);
-        $application->setPlainPassword($plainPassword);
-        $encoded = $encoder->encodePassword($application, $plainPassword);
-        $application->setPassword($encoded);
-
         $em->persist($application);
         $em->flush();
 
         $clientManager = $this->container->get('fos_oauth_server.client_manager.default');
         $client = $clientManager->createClient();
         $client->setRedirectUris(array($application->getUri()));
-        $client->setAllowedGrantTypes(array('password'));
+        $client->setAllowedGrantTypes(array('password', 'refresh_token'));
         $client->setApplication($application);
         $clientManager->updateClient($client);
 
         return $this->view(
-            [$application, $client],
+            [$client],
             Response::HTTP_CREATED,
             ['Location' => $this->generateUrl('api_application_view', ['id' => $application->getId(), UrlGeneratorInterface::ABSOLUTE_URL])]
         );

--- a/api/src/AppBundle/DoctrineListener/ApplicationCreationListener.php
+++ b/api/src/AppBundle/DoctrineListener/ApplicationCreationListener.php
@@ -11,11 +11,11 @@
 		/**
 		 * @var ApplicationPasswordGenerator
 		 */
-		private $applicationPasswordGenerator;
+		private $passwordGenerator;
 
-		public function __construct(ApplicationPasswordGenerator $applicationPasswordGenerator)
+		public function __construct(ApplicationPasswordGenerator $passwordGenerator)
 		{
-			$this->applicationPasswordGenerator = $applicationPasswordGenerator;
+			$this->passwordGenerator = $passwordGenerator;
 		}
 
 		public function prePersist(LifecycleEventArgs $args)
@@ -28,6 +28,6 @@
 			}
 
 			//Generate password
-			$this->applicationPasswordGenerator->generatePassword($entity);
+			$this->passwordGenerator->generatePassword($entity);
 		}
 	}

--- a/api/src/AppBundle/DoctrineListener/ApplicationCreationListener.php
+++ b/api/src/AppBundle/DoctrineListener/ApplicationCreationListener.php
@@ -1,0 +1,33 @@
+<?php
+
+	namespace AppBundle\DoctrineListener;
+	
+	use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+	use AppBundle\Services\ApplicationPasswordGenerator;
+	use AppBundle\Entity\Application;
+
+	class ApplicationCreationListener
+	{		
+		/**
+		 * @var ApplicationPasswordGenerator
+		 */
+		private $applicationPasswordGenerator;
+
+		public function __construct(ApplicationPasswordGenerator $applicationPasswordGenerator)
+		{
+			$this->applicationPasswordGenerator = $applicationPasswordGenerator;
+		}
+
+		public function prePersist(LifecycleEventArgs $args)
+		{
+			$entity = $args->getObject();
+
+			//Only if entity is an instance of Application
+			if (!$entity instanceof Application) {
+				return;
+			}
+
+			//Generate password
+			$this->applicationPasswordGenerator->generatePassword($entity);
+		}
+	}

--- a/api/src/AppBundle/DoctrineListener/ClientCreationListener.php
+++ b/api/src/AppBundle/DoctrineListener/ClientCreationListener.php
@@ -1,0 +1,33 @@
+<?php
+
+	namespace AppBundle\DoctrineListener;
+	
+	use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+	use AppBundle\Services\ClientMailer;
+	use AppBundle\Entity\Client;
+
+	class ClientCreationListener
+	{		
+		/**
+		 * @var ClientMailer
+		 */
+		private $clientMailer;
+
+		public function __construct(ClientMailer $clientMailer)
+		{
+			$this->clientMailer = $clientMailer;
+		}
+
+		public function postPersist(LifecycleEventArgs $args)
+		{
+			$entity = $args->getObject();
+
+			//Only if entity is an instance of Client
+			if (!$entity instanceof Client) {
+				return;
+			}
+			
+			//Send mail
+			$this->clientMailer->sendCredentialsEmail($entity);
+		}
+	}

--- a/api/src/AppBundle/Services/ApplicationPasswordGenerator.php
+++ b/api/src/AppBundle/Services/ApplicationPasswordGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+	namespace AppBundle\Services;
+	
+	use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+	use AppBundle\Entity\Application;
+
+	class ApplicationPasswordGenerator
+	{
+		/**
+		 * @var UserPasswordEncoderInterface
+		 */
+		private $encoder;
+
+		public function __construct(UserPasswordEncoderInterface $encoder)
+		{
+			$this->encoder = $encoder;
+		}
+
+		public function generatePassword(Application $application)
+		{
+			$chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+	        $plainPassword = substr(str_shuffle($chars), 0, 25);
+	        $fullPlainPassword = $application->getUsername()."_".$plainPassword;
+	        $encoded = $this->encoder->encodePassword($application, $fullPlainPassword);
+	        $application->setPlainPassword($fullPlainPassword);
+	        $application->setPassword($encoded);
+		}
+	}

--- a/api/src/AppBundle/Services/ClientMailer.php
+++ b/api/src/AppBundle/Services/ClientMailer.php
@@ -1,0 +1,44 @@
+<?php
+
+	namespace AppBundle\Services;
+
+	use AppBundle\Entity\Client;
+
+	class ClientMailer
+	{
+		/**
+		 * @var \Swift_Mailer
+		 */
+		private $mailer;
+
+		/**
+		 * @var [type]
+		 */
+		private $templating;
+
+		public function __construct(\Swift_Mailer $mailer, $templating)
+		{
+			$this->mailer = $mailer;
+			$this->templating = $templating;
+		}
+
+		public function sendCredentialsEmail(Client $client)
+		{
+			$message = (new \Swift_Message('Welcome to Bilemo Galaxy!'))
+				->setFrom('pookiedonnut@gmail.com')
+				->setTo($client->getApplication()->getEmail())
+				->setBody(
+					$this->templating->render(
+						'Email/client_creation.html.twig',
+						array(
+							'client_id' => $client->getPublicId(),
+							'client_secret' => $client->getSecret(),
+							'username' => $client->getApplication()->getUsername(),
+							'password' => $client->getApplication()->getPlainPassword()
+						)
+					)
+				);
+
+				$this->mailer->send($message);
+		}
+	}


### PR DESCRIPTION
**Needs:**
Generate password on new application creation.
Send email to new application partner with credentials to access Bilemo API.

**Before:**
Password generation was inside the createAction in ApplicationController. 
Nothing about sending credentials to partner.

**Now:**
2 Doctrine listeners were created to:
- generate password for new application (application - prePersist)
- send email to new B2B partner with credentials (FOSOAuthServer client - postPersist)



 